### PR TITLE
Valhalla fix

### DIFF
--- a/scripts/build_poly_tilemasks.py
+++ b/scripts/build_poly_tilemasks.py
@@ -7,8 +7,32 @@ import json
 import argparse
 import utils.polygon2geojson as polygon2geojson
 import utils.tilemask as tilemask
+import functools
+import re
+import geojson
 
 TILEMASK_SIZE_THRESHOLD = 512
+
+def bbox(coord_list):
+     box = []
+     for i in (0,1):
+         res = sorted(coord_list, key=lambda x:x[i])
+         box.append((res[0][i],res[-1][i]))
+     return box
+
+
+def read_polygon(polygon_filename):
+  with open(polygon_filename) as f:
+    return f.readlines()
+
+def clean_polygon(polygon_data):
+  coordinates = polygon_data[2:][:-2]
+  coordinates = [re.split(r'[\s\t]+', item) for item in coordinates]
+  coordinates = [list(filter(None, item)) for item in coordinates]
+  coordinates = functools.reduce(lambda a,b: a[-1].pop(0) and a if len(a[-1]) == 1 and a[-1][0] == 'END' else a.append(['END']) or a if b[0].startswith('END') else a[-1].append(b) or a, [[[]]] + coordinates)
+  coordinates = [[(float(item[0]), float(item[1])) for item in coordgroup] for coordgroup in coordinates]
+  return coordinates
+
 
 def main():
   parser = argparse.ArgumentParser()
@@ -32,11 +56,16 @@ def main():
       if len(mask) >= TILEMASK_SIZE_THRESHOLD:
         break
 
+    polygon_data = read_polygon(polyFilename)
+    coordinates = clean_polygon(polygon_data)
+    poly=geojson.Polygon(coordinates)
+    line = bbox(list(geojson.utils.coords(poly)))
     packages.append(
       {
         'id': packageId,
         'version': 1,
         'tile_mask': str(mask, 'utf8'),
+        'bbox': (line[0][0], line[1][0], line[0][1],line[1][1]),
         'url': '', 
         'metainfo': { 'name_en': packageName },
         'size': 0


### PR DESCRIPTION
So as i mentionned here https://github.com/nutiteq/mobile-sdk-scripts/issues/2
with sub osm extract the valhalla build scripts seems to be looking for the wrong tiles.
I fixed in the way :
* store the bbox of the poly for each package
* compute vtiles using [this](code)

It is also much faster as building tiles list from tilemask seems pretty slow.
In this case it means the tilemask is actually not needed anymore.

There is also code cleanup of consequently unecessary code and a VACUUM cleanup